### PR TITLE
[WEB] Diggy Diggy Hole

### DIFF
--- a/web/diggy-diggy-hole/README.md
+++ b/web/diggy-diggy-hole/README.md
@@ -1,0 +1,17 @@
+# Diggy Diggy Hole
+## Problem
+I found this super sketchy website called [hole.sketchy.dev](https://hole.sketchy.dev). Can you help me `dig` up some of its secrets?
+
+Oh, and someone told me that the secrets are `TXT`. I don't know what this means, so good luck!
+
+## Hints
+* What does `dig` on Linux do?
+* How might you use `dig` to view `TXT`?
+* Domain Name System
+
+## Flag
+```
+bcactf{d1g-f0r-h073s-w/-dns-8044323}
+```
+
+> Problem submitted by [**@anli5005**](https://anli.dev)

--- a/web/diggy-diggy-hole/solution/README.md
+++ b/web/diggy-diggy-hole/solution/README.md
@@ -1,0 +1,13 @@
+# Diggy Diggy Hole Writeup
+
+## Necessary Tools
+* A tool capable of inspecting the DNS records for a given website.
+
+## Procedure
+In this procedure, we'll be using `dig`, a DNS utility that comes with most \*nix systems.
+
+1. In the command line, run:
+  ```shell
+  $ dig hole.sketchy.dev TXT
+  ```
+2. Inspect the output. The flag, indicated by `bcactf`, should be there.


### PR DESCRIPTION
This is a DNS problem where the flag is stored as a `TXT` record under a domain named [hole.sketchy.dev](https://hole.sketchy.dev). It should be rather interesting.